### PR TITLE
update version to 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spire-workload"
-version = "1.1.5"
+version = "1.2.0"
 authors = ["Maxwell Bruce", "Yu Ding", "Ruide Zhang"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
The version should bump to 1.2.0 since the latest master code (1.1.5) is not compatible with 1.1.4, Rustls (`rustls::ServerConfig`, `rustls::ClientConfig`) WebPKI has breaking change. 

The published version on crates.io should also be disabled to avoid confusion.

cc: @dingelish @Ruide 