### PR TITLE
Support customize spiffeID separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .vscode
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spire-workload"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Maxwell Bruce", "Yu Ding", "Ruide Zhang"]
 edition = "2018"
 build = "build.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use rustls::ClientConfig;
 use rustls::{sign::CertifiedKey, PrivateKey};
 use rustls::{Certificate, RootCertStore};
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::watch::{channel, Receiver, Sender};
 use verifier::DynamicLoadedCertResolverVerifier;
@@ -96,6 +96,7 @@ impl Ord for CrlEntry {
 }
 
 pub static CURRENT_IDENTITY_VERSION: AtomicU64 = AtomicU64::new(0);
+pub static SPIFFEID_SEPARATOR: AtomicU8 = AtomicU8::new(58);
 
 lazy_static! {
     pub(crate) static ref IDENTITY_UPDATE_WATCHER: (Sender<u64>, Receiver<u64>) = channel(0);
@@ -103,6 +104,8 @@ lazy_static! {
     pub static ref JWT_BUNDLES: ArcSwap<BTreeMap<String, Arc<JwtBundle>>> = ArcSwap::new(Arc::new(BTreeMap::new()));
     // unused
     pub static ref CERTIFICATE_REVOKATION_LIST: ArcSwap<BTreeSet<CrlEntry>> = ArcSwap::new(Arc::new(BTreeSet::new()));
+
+    pub static ref VALID_SPIFFEID_SEPARATORS: Vec<char> = vec![':', '-', '.', '_'];
 }
 
 pub async fn wait_for_identity_update(current_version: Option<u64>) -> Option<u64> {
@@ -184,4 +187,26 @@ pub fn make_server_config(
     config.alpn_protocols = Vec::from(protocols);
 
     config
+}
+
+pub fn set_spiffe_separator(
+    separator: &str
+) -> Result<()>{
+    
+    if separator.len() != 1 {
+        return Err(anyhow!("invalid spiffe separator length: {}", separator.len()));
+    }
+
+    match &separator.chars().next() {
+        None => return Err(anyhow!("empty spiffe separator")),
+        Some(c) => {
+            if !VALID_SPIFFEID_SEPARATORS.contains(c){
+                return Err(anyhow!("invalid spiffe separator char: {}", separator));
+            }
+            SPIFFEID_SEPARATOR.store(*c as u8, Ordering::SeqCst);
+
+        },
+      };
+
+    Ok(())
 }

--- a/src/spiffe.rs
+++ b/src/spiffe.rs
@@ -1,9 +1,11 @@
+use super::SPIFFEID_SEPARATOR;
 use anyhow::{anyhow, Result};
 use serde::{
     de::{Unexpected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::collections::BTreeMap;
+use std::sync::atomic::Ordering;
 use std::fmt;
 use url::Url;
 use x509_parser::extensions::GeneralName;
@@ -132,12 +134,13 @@ impl SpiffeID {
             .path_segments()
             .map(|x| x.collect::<Vec<&str>>())
             .unwrap_or_default();
+        let separator = SPIFFEID_SEPARATOR.load(Ordering::SeqCst);
         let mut components: BTreeMap<String, String> = BTreeMap::new();
         for segment in segments {
             if segment.is_empty() {
                 continue;
             }
-            let split_index = segment.find(':');
+            let split_index = segment.find(separator as char);
             if split_index.is_none() {
                 return Err(anyhow!("malformed component in spiffe url: '{}'", segment));
             }
@@ -188,7 +191,7 @@ impl fmt::Display for SpiffeID {
             self.trust_domain,
             self.components
                 .iter()
-                .map(|(name, value)| format!("{}:{}", name, value))
+                .map(|(name, value)| format!("{}{}{}", name, SPIFFEID_SEPARATOR.load(Ordering::SeqCst) as char ,value))
                 .collect::<Vec<String>>()
                 .join("/")
         )
@@ -204,8 +207,9 @@ impl fmt::Display for SpiffeIDMatcher {
             self.components
                 .iter()
                 .map(|(name, value)| format!(
-                    "{}:{}",
+                    "{}{}{}",
                     name,
+                    SPIFFEID_SEPARATOR.load(Ordering::SeqCst) as char,
                     value.as_ref().map(|x| &**x).unwrap_or("*")
                 ))
                 .collect::<Vec<String>>()
@@ -276,6 +280,7 @@ impl SpiffeIDMatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::set_spiffe_separator;
 
     #[test]
     fn test_spiffe_matcher_basic() -> Result<()> {
@@ -423,6 +428,7 @@ mod tests {
 
     #[test]
     fn test_spiffe_matcher_matching_wildcard() -> Result<()> {
+        set_spiffe_separator(":").unwrap();
         let spiffe_matcher = SpiffeIDMatcher::new(Url::parse(
             "spiffe://spiffe-test/ns:*/r:us/vdc:d/id:security.platform.kms_client",
         )?)?;
@@ -573,6 +579,26 @@ mod tests {
     fn test_spiffe_component_reset() -> Result<()> {
         SpiffeID::new(Url::parse(
             "spiffe://spiffe-test/ns:tce/ns:tce/r:us/vdc:useast2a/id:security.platform.kms_client",
+        )?)
+        .unwrap_err();
+        Ok(())
+    }
+
+    #[test]
+    fn test_spiffe_component_reset_with_separator() -> Result<()> {
+        set_spiffe_separator("_").unwrap();
+        SpiffeID::new(Url::parse(
+            "spiffe://spiffe-test/ns_tce/ns_tce/r_cn/vdc_boe/id_security.platform.kms_client",
+        )?)
+        .unwrap_err();
+        set_spiffe_separator(":").unwrap();
+        Ok(())
+    }
+    #[test]
+    fn test_spiffe_component_reset_with_invalid_separator() -> Result<()> {
+        assert!(!set_spiffe_separator("!").is_ok());
+        SpiffeID::new(Url::parse(
+            "spiffe://spiffe-test/ns:tce/ns:tce/r:cn/vdc:boe/id:security.platform.kms_client",
         )?)
         .unwrap_err();
         Ok(())


### PR DESCRIPTION
- Add set_spiffe_separator function to set spiffeID separator, default: ":"
- Add SPIFFEID_SEPARATOR and VALID_SPIFFEID_SEPARATORS variable
- The list of valid spiffeID separator is ":", "-", "." , "_"